### PR TITLE
Fix hot reloading

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -7,7 +7,6 @@
   "devDependencies": {
     "babel-core": "5.8.23",
     "babel-loader": "5.3.2",
-    "react-hot-loader": "1.3.0",
     "webpack": "1.12.1",
     "webpack-dev-server": "1.10.1"
   },

--- a/examples/counter/src/counter.js
+++ b/examples/counter/src/counter.js
@@ -1,11 +1,5 @@
-import {Record, Union} from "typed-immutable";
 import {html} from "reflex";
-
-export const Model = Record({value: Number});
-
-export const Increment = Record({label: '+'});
-export const Decrement = Record({label: '-'});
-export const Action = Union(Increment, Decrement);
+import { Increment, Decrement } from './types';
 
 // Update
 export const update = (model, action) =>

--- a/examples/counter/src/index.js
+++ b/examples/counter/src/index.js
@@ -1,4 +1,20 @@
 import {main} from "reflex";
-import * as Counter from "./counter";
+import {Model} from './types';
 
-main(document.body, Counter.Model({value: 0}), Counter.update, Counter.view);
+let { update, view } = require('./counter');
+if (module.hot) {
+  // Replace the pure functions on hot update
+  module.hot.accept('./counter', function () {
+    ({ update, view } = require('./counter'));
+    application.schedule();
+  });
+}
+
+let application = main(
+  document.body,
+  Model({value: 0}),
+  // Use lambdas to proxy to newest available version
+  (model, action) => update(model, action),
+  (model, address) => view(model, address)
+);
+

--- a/examples/counter/src/types.js
+++ b/examples/counter/src/types.js
@@ -1,0 +1,7 @@
+import {Record, Union} from "typed-immutable";
+
+export const Model = Record({value: Number});
+export const Increment = Record({label: '+'});
+export const Decrement = Record({label: '-'});
+export const Action = Union(Increment, Decrement);
+

--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js$/,
-      loaders: ['react-hot', 'babel'],
+      loaders: ['babel'],
       include: path.resolve('./src')
     }]
   }


### PR DESCRIPTION
This fixes hot reloading as requested in https://github.com/gaearon/react-hot-loader/issues/191.

I removed React Hot Loader because it is irrelevant here.
Instead, I'm using vanilla Webpack Hot Module Replacement API.

Interesting bits:

* I split `types` because we don't want to reevaluate them—this seems to screw things up due to their previous versions being used somewhere inside Reflex and the reliance on `instanceof` checks.

* I changed `import` to `let` assignment because I need to update it continually in response to new module versions. Conceivably one could write a Webpack loader to turn a module into observable of exports instead but I don't think it's worth bothering.

You can now update anything in `./counter` (both view and updater functions) and it should Just Work.

Cheers!
Love Reflex and eager to play more with it.