### PR TITLE
Version 0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-plugin-transform-flow-strip-types": "6.4.0",
     "babel-preset-es2015": "6.3.13",
     "babel-register": "6.4.3",
-    "flow-bin": "0.23.0",
+    "flow-bin": "0.24.1",
     "tap": "1.1.0",
     "tape": "4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reflex",
   "id": "reflex",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Functional reactive UI library",
   "keywords": [
     "reflex",

--- a/src/dom.js
+++ b/src/dom.js
@@ -29,6 +29,7 @@ class VirtualRoot /*::<model, action>*/ {
     this.address = address
   }
   renderWith(current/*:Driver*/) {
+    let exception = null
     const previous = driver
     driver = current
 
@@ -36,10 +37,14 @@ class VirtualRoot /*::<model, action>*/ {
       driver.render(this.view(this.model, this.address))
     }
     catch(error) {
-      driver = previous
-      throw error
+      exception = error
     }
+
     driver = previous
+
+    if (exception != null) {
+      throw exception
+    }
   }
 }
 VirtualRoot.prototype.$type = "VirtualRoot"

--- a/src/dom.js
+++ b/src/dom.js
@@ -10,6 +10,7 @@ export type {Text, Key, TagName, DOM}
 */
 
 let driver/*:?Driver*/ = null
+const absent = new String("absent")
 
 class VirtualRoot /*::<model, action>*/ {
   /*::
@@ -29,7 +30,7 @@ class VirtualRoot /*::<model, action>*/ {
     this.address = address
   }
   renderWith(current/*:Driver*/) {
-    let exception = null
+    let exception = absent
     const previous = driver
     driver = current
 
@@ -42,7 +43,7 @@ class VirtualRoot /*::<model, action>*/ {
 
     driver = previous
 
-    if (exception != null) {
+    if (exception != absent) {
       throw exception
     }
   }

--- a/src/effects.js
+++ b/src/effects.js
@@ -36,7 +36,7 @@ export class Effects /*::<a>*/ {
   }
   static receive /*::<a>*/(action/*:a*/)/*:Effects<a>*/ {
     const fx =
-      new Effects
+      new Perform
       ( new Task
         ( (succeed, fail) =>
           void

--- a/src/effects.js
+++ b/src/effects.js
@@ -26,8 +26,9 @@ export class Effects /*::<a>*/ {
   static task /*::<a>*/(task/*:Task<Never, a>*/)/*:Effects<a>*/ {
     return new Perform(task)
   }
-  static tick /*::<a>*/(tag/*:(time:Time) => a*/)/*:Effects<a>*/ {
-    return new Tick(tag)
+  static tick /*::<a>*/(tag/*:(time:number) => a*/)/*:Effects<a>*/ {
+    console.warn('Effects.tick is deprecated please use Effects.perform(Task.requestAnimationFrame.map(tag)) instead')
+    return new Perform(Task.requestAnimationFrame().map(tag))
   }
   static receive /*::<a>*/(action/*:a*/)/*:Effects<a>*/ {
     const fx =
@@ -109,103 +110,3 @@ class Batch /*::<a>*/ extends Effects /*::<a>*/ {
     })
   }
 }
-
-
-class Tick /*::<a>*/ extends Effects /*::<a>*/ {
-  /*::
-  tag: (time:Time) => a;
-  */
-  constructor(tag/*:(time:Time) => a*/) {
-    super(never)
-    this.tag = tag
-  }
-  map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
-    return new Tick((time/*:Time*/) => f(this.tag(time)))
-  }
-  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
-    const task =
-      new Task
-      ( (succeed, fail) =>
-        animationScheduler.schedule(time => succeed(this.tag(time)))
-      )
-      .chain(action => Task.send(address, action))
-    return task
-  }
-}
-
-// Invariants:
-// 1. In the NO_REQUEST state, there is never a scheduled animation frame.
-// 2. In the PENDING_REQUEST and EXTRA_REQUEST states, there is always exactly
-// one scheduled animation frame.
-const NO_REQUEST = 0
-const PENDING_REQUEST = 1
-const EXTRA_REQUEST = 2
-
-
-/*::
-type Time = number
-type State = 0 | 1 | 2
-*/
-
-class AnimationScheduler {
-  /*::
-  state: State;
-  requests: Array<(time:Time) => any>;
-  execute: (time:Time) => void;
-  */
-  constructor() {
-    this.state = NO_REQUEST
-    this.requests = []
-    this.execute = this.execute.bind(this)
-  }
-  schedule(request) {
-    if (this.state === NO_REQUEST) {
-      window.requestAnimationFrame(this.execute)
-    }
-
-    this.requests.push(request)
-    this.state = PENDING_REQUEST
-  }
-  execute(time/*:Time*/)/*:void*/ {
-    switch (this.state) {
-      case NO_REQUEST:
-        // This state should not be possible. How can there be no
-        // request, yet somehow we are actively fulfilling a
-        // request?
-        throw Error(`Unexpected frame request`)
-      case PENDING_REQUEST:
-        // At this point, we do not *know* that another frame is
-        // needed, but we make an extra frame request just in
-        // case. It's possible to drop a frame if frame is requested
-        // too late, so we just do it preemptively.
-        window.requestAnimationFrame(this.execute)
-        this.state = EXTRA_REQUEST
-        this.dispatch(this.requests.splice(0), 0, time)
-        break
-      case EXTRA_REQUEST:
-        // Turns out the extra request was not needed, so we will
-        // stop requesting. No reason to call it all the time if
-        // no one needs it.
-        this.state = NO_REQUEST
-        break
-    }
-  }
-  dispatch(requests, index, time) {
-    const count = requests.length
-    try {
-      while (index < count) {
-        const request = requests[index]
-        index = index + 1
-        request(time)
-      }
-    }
-    catch (error) {
-      if (index < count) {
-        this.dispatch(requests, index, time)
-      }
-      throw error
-    }
-  }
-}
-
-const animationScheduler = new AnimationScheduler()

--- a/src/effects.js
+++ b/src/effects.js
@@ -74,6 +74,9 @@ class Perform /*::<a>*/ extends Effects /*::<a>*/ {
   map /*::<b>*/ (f/*:(a:a)=>b*/)/*:Effects<b>*/ {
     return new Perform(this.task.map(f))
   }
+  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
+    return this.task.chain(value => Task.send(address, value))
+  }
 }
 
 class None /*::<a>*/ extends Effects /*::<any>*/ {

--- a/src/effects.js
+++ b/src/effects.js
@@ -24,6 +24,10 @@ const never =
 
 export class Effects /*::<a>*/ {
   static task /*::<a>*/(task/*:Task<Never, a>*/)/*:Effects<a>*/ {
+    console.warn('Effects.task is deprecated please use Effects.perform instead')
+    return new Perform(task)
+  }
+  static perform /*::<a>*/(task/*:Task<Never, a>*/)/*:Effects<a>*/ {
     return new Perform(task)
   }
   static tick /*::<a>*/(tag/*:(time:number) => a*/)/*:Effects<a>*/ {

--- a/src/effects.js
+++ b/src/effects.js
@@ -24,7 +24,7 @@ const never =
 
 export class Effects /*::<a>*/ {
   static task /*::<a>*/(task/*:Task<Never, a>*/)/*:Effects<a>*/ {
-    return new Effects(task)
+    return new Perform(task)
   }
   static tick /*::<a>*/(tag/*:(time:Time) => a*/)/*:Effects<a>*/ {
     return new Tick(tag)
@@ -56,22 +56,22 @@ export class Effects /*::<a>*/ {
   /*::
   static none:Effects<any>;
   task: Task<Never, a>;
+  map: <b> (f:(a:a)=>b) => Effects<b>;
+  send: (address:Address<a>) => Task<Never, void>;
   */
+}
+
+class Perform /*::<a>*/ extends Effects /*::<a>*/ {
   constructor(task/*:Task<Never, a>*/) {
+    super()
     this.task = task
   }
-  map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
-    return new Effects(this.task.map(f))
-  }
-  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
-    return this.task.chain(value => Task.send(address, value))
+  map /*::<b>*/ (f/*:(a:a)=>b*/)/*:Effects<b>*/ {
+    return new Perform(this.task.map(f))
   }
 }
 
 class None /*::<a>*/ extends Effects /*::<any>*/ {
-  constructor() {
-    super(never)
-  }
   map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
     return Effects.none
   }
@@ -86,7 +86,7 @@ class Batch /*::<a>*/ extends Effects /*::<a>*/ {
   effects: Array<Effects<a>>;
   */
   constructor(effects/*:Array<Effects<a>>*/) {
-    super(never)
+    super()
     this.effects = effects
   }
   map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {

--- a/src/effects.js
+++ b/src/effects.js
@@ -31,7 +31,7 @@ export class Effects /*::<a>*/ {
     return new Perform(task)
   }
   static tick /*::<a>*/(tag/*:(time:number) => a*/)/*:Effects<a>*/ {
-    console.warn('Effects.tick is deprecated please use Effects.perform(Task.requestAnimationFrame.map(tag)) instead')
+    console.warn('Effects.tick is deprecated please use Effects.perform(Task.requestAnimationFrame().map(tag)) instead')
     return new Perform(Task.requestAnimationFrame().map(tag))
   }
   static receive /*::<a>*/(action/*:a*/)/*:Effects<a>*/ {

--- a/src/effects.js.flow
+++ b/src/effects.js.flow
@@ -10,6 +10,7 @@ export type Never = Never
 declare export class Effects <a>
   { static none: Effects<any>
   , static task <a> (task:Task<Never, a>):Effects<a>
+  , static perform <a> (task:Task<Never, a>):Effects<a>
   , static tick <a> (tag:(time:Time) => a):Effects<a>
   , static receive <a> (action:a):Effects<a>
   , static batch <a> (effecs:Array<Effects<a>>):Effects<a>

--- a/src/preemptive-animation-frame.js
+++ b/src/preemptive-animation-frame.js
@@ -74,6 +74,7 @@ const dispatchAnimationFrame = /*::<a>*/
   , index/*:number*/
   , time/*:Time*/
   ) => {
+    let exception = null
     const count = requests.length
     try {
       while (index < count) {
@@ -83,9 +84,14 @@ const dispatchAnimationFrame = /*::<a>*/
       }
     }
     catch (error) {
-      if (index < count) {
-        dispatchAnimationFrame(requests, index, time)
-      }
-      throw error
+      exception = error
+    }
+
+    if (index < count) {
+      dispatchAnimationFrame(requests, index, time)
+    }
+
+    if (exception != null) {
+      throw exception
     }
   }

--- a/src/preemptive-animation-frame.js
+++ b/src/preemptive-animation-frame.js
@@ -27,6 +27,7 @@ export const requestAnimationFrame = /*::<a>*/
     const id = ++nextID
     requests.push(request)
     ids.push(id)
+    state = PENDING_REQUEST
     return id
   }
 
@@ -58,6 +59,7 @@ const performAnimationFrame =
         // too late, so we just do it preemptively.
         window.requestAnimationFrame(performAnimationFrame)
         state = EXTRA_REQUEST
+        ids.splice(0)
         dispatchAnimationFrame(requests.splice(0), 0, time)
         break
       case EXTRA_REQUEST:

--- a/src/preemptive-animation-frame.js
+++ b/src/preemptive-animation-frame.js
@@ -1,0 +1,91 @@
+/* @flow */
+
+/*::
+type Time = number
+type State = 0 | 1 | 2
+*/
+
+// Invariants:
+// 1. In the NO_REQUEST state, there is never a scheduled animation frame.
+// 2. In the PENDING_REQUEST and EXTRA_REQUEST states, there is always exactly
+// one scheduled animation frame.
+const NO_REQUEST = 0
+const PENDING_REQUEST = 1
+const EXTRA_REQUEST = 2
+
+let nextID/*:number*/ = 0
+let state/*:State*/ = NO_REQUEST
+let requests/*:Array<(time:Time) => any>*/ = []
+let ids/*:Array<number>*/ = []
+
+export const requestAnimationFrame = /*::<a>*/
+  (request/*:(time:Time) => a*/) => {
+    if (state === NO_REQUEST) {
+      window.requestAnimationFrame(performAnimationFrame)
+    }
+
+    const id = ++nextID
+    requests.push(request)
+    ids.push(id)
+    return id
+  }
+
+export const cancelAnimationFrame =
+  (id/*:number*/)/*:void*/ => {
+    const index = ids.indexOf(id);
+    if (index >= 0) {
+      ids.splice(index, 1)
+      requests.splice(index, 1)
+    }
+  }
+
+export const forceAnimationFrame =
+  (time/*:Time*/=window.performance.now()) =>
+  performAnimationFrame(time);
+
+const performAnimationFrame =
+  (time/*:Time*/) => {
+    switch (state) {
+      case NO_REQUEST:
+        // This state should not be possible. How can there be no
+        // request, yet somehow we are actively fulfilling a
+        // request?
+        throw Error(`Unexpected frame request`)
+      case PENDING_REQUEST:
+        // At this point, we do not *know* that another frame is
+        // needed, but we make an extra frame request just in
+        // case. It's possible to drop a frame if frame is requested
+        // too late, so we just do it preemptively.
+        window.requestAnimationFrame(performAnimationFrame)
+        state = EXTRA_REQUEST
+        dispatchAnimationFrame(requests.splice(0), 0, time)
+        break
+      case EXTRA_REQUEST:
+        // Turns out the extra request was not needed, so we will
+        // stop requesting. No reason to call it all the time if
+        // no one needs it.
+        state = NO_REQUEST
+        break
+    }
+  }
+
+const dispatchAnimationFrame = /*::<a>*/
+  ( requests/*:Array<(time:Time) => a>*/
+  , index/*:number*/
+  , time/*:Time*/
+  ) => {
+    const count = requests.length
+    try {
+      while (index < count) {
+        const request = requests[index]
+        index = index + 1
+        request(time)
+      }
+    }
+    catch (error) {
+      if (index < count) {
+        dispatchAnimationFrame(requests, index, time)
+      }
+      throw error
+    }
+  }

--- a/src/preemptive-animation-frame.js
+++ b/src/preemptive-animation-frame.js
@@ -18,6 +18,8 @@ let state/*:State*/ = NO_REQUEST
 let requests/*:Array<(time:Time) => any>*/ = []
 let ids/*:Array<number>*/ = []
 
+const absent = new String("absent")
+
 export const requestAnimationFrame = /*::<a>*/
   (request/*:(time:Time) => a*/) => {
     if (state === NO_REQUEST) {
@@ -76,7 +78,7 @@ const dispatchAnimationFrame = /*::<a>*/
   , index/*:number*/
   , time/*:Time*/
   ) => {
-    let exception = null
+    let exception = absent
     const count = requests.length
     try {
       while (index < count) {
@@ -93,7 +95,7 @@ const dispatchAnimationFrame = /*::<a>*/
       dispatchAnimationFrame(requests, index, time)
     }
 
-    if (exception != null) {
+    if (exception != absent) {
       throw exception
     }
   }

--- a/src/signal.js
+++ b/src/signal.js
@@ -29,6 +29,7 @@ class Input /*::<a>*/ {
     }
   }
   static notify(message/*:a*/, addressBook/*:AddressBook<a>*/, from/*:number*/, to/*:number*/)/*:void*/ {
+    let exception = null
     try {
       while (from < to) {
         const address = addressBook[from]
@@ -39,10 +40,15 @@ class Input /*::<a>*/ {
       }
     }
     catch (error) {
-      if (from < to) {
-        Input.notify(message, addressBook, from + 1, to)
-      }
-      throw error
+      exception = error
+    }
+
+    if (from < to) {
+      Input.notify(message, addressBook, from + 1, to)
+    }
+
+    if (exception != null) {
+      throw exception
     }
   }
   static connect(signal/*:Input<a>*/, address/*:Address<a>*/) {
@@ -76,6 +82,7 @@ class Input /*::<a>*/ {
         this.queue.push(value)
       }
     } else {
+      let exception = null
       this.isBlocked = true
       try {
         this.value = value
@@ -85,15 +92,18 @@ class Input /*::<a>*/ {
           Input.notify(value, addressBook, 0, addressBook.length)
         }
       }
-      catch(error) {
-        this.isBlocked = false
-        if (this.queue != null && this.queue.length > 0) {
-          this.receive(value = this.queue.shift())
-        }
-
-        throw error
+      catch (error) {
+        exception = error
       }
+
       this.isBlocked = false
+      if (this.queue != null && this.queue.length > 0) {
+        this.receive(value = this.queue.shift())
+      }
+
+      if (exception != null) {
+        throw exception
+      }
     }
   }
   subscribe(address/*:Address<a>*/)/*:void*/ {

--- a/src/signal.js
+++ b/src/signal.js
@@ -9,6 +9,8 @@ export type {Signal, Address, Mailbox}
 export type {Translate, Reducer, AddressBook}
 */
 
+const absent = new String("absent")
+
 class Input /*::<a>*/ {
   /*::
   $type: "Signal.Signal";
@@ -29,7 +31,7 @@ class Input /*::<a>*/ {
     }
   }
   static notify(message/*:a*/, addressBook/*:AddressBook<a>*/, from/*:number*/, to/*:number*/)/*:void*/ {
-    let exception = null
+    let exception = absent
     try {
       while (from < to) {
         const address = addressBook[from]
@@ -47,7 +49,7 @@ class Input /*::<a>*/ {
       Input.notify(message, addressBook, from + 1, to)
     }
 
-    if (exception != null) {
+    if (exception != absent) {
       throw exception
     }
   }
@@ -82,7 +84,7 @@ class Input /*::<a>*/ {
         this.queue.push(value)
       }
     } else {
-      let exception = null
+      let exception = absent
       this.isBlocked = true
       try {
         this.value = value
@@ -101,7 +103,7 @@ class Input /*::<a>*/ {
         this.receive(value = this.queue.shift())
       }
 
-      if (exception != null) {
+      if (exception != absent) {
         throw exception
       }
     }

--- a/src/task.js
+++ b/src/task.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import {requestAnimationFrame, cancelAnimationFrame} from "./preemptive-animation-frame"
 
 /*::
 import type {Address} from "./signal"
@@ -32,6 +33,10 @@ export class Task /*::<x, a>*/ {
 
   static sleep /*::<x>*/ (time:Time)/*:Task<x, void>*/ {
     return new Sleep(time)
+  }
+
+  static requestAnimationFrame /*::<x>*/ ()/*:Task<x, Time>*/ {
+    return new RequestAnimationFrame()
   }
 
   static send /*::<x, a>*/ (address/*:Address<a>*/, message/*:a*/)/*:Task<x, void>*/ {
@@ -104,6 +109,16 @@ class Sleep /*::<x, a:void>*/ extends Task /*::<x, void>*/ {
   fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:?Abort<void>*/ {
     const id = setTimeout(succeed, this.time, void(0))
     return () => clearTimeout(id)
+  }
+}
+
+class RequestAnimationFrame /*::<x>*/ extends Task /*::<x, Time>*/ {
+  constructor() {
+    super()
+  }
+  fork(succeed/*:(a:Time) => void*/, fail/*:(x:x) => void*/)/*:?Abort<void>*/ {
+    const id = requestAnimationFrame(succeed);
+    return () => cancelAnimationFrame(id);
   }
 }
 

--- a/src/task.js
+++ b/src/task.js
@@ -77,7 +77,6 @@ export class Task /*::<x, a>*/ {
   fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:any*/ {
   }
   abort /*::<handle>*/(handle/*:handle*/)/*:void*/ {
-
   }
 }
 

--- a/src/task.js
+++ b/src/task.js
@@ -59,6 +59,9 @@ export class Task /*::<x, a>*/ {
   format /*::<y>*/ (f/*:(input:x) => y*/)/*:Task<y, a>*/ {
     return new Format(this, f)
   }
+  recover (regain/*:(error:x) => a*/)/*:Task<x, a>*/ {
+    return new Recover(this, regain)
+  }
   fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:?Abort<any>*/ {
   }
 }
@@ -213,6 +216,19 @@ class Capture/*::<x, y, a>*/extends Catch/*::<x, y, a>*/{
   constructor(task/*:Task<x, a>*/, handle/*:(error:x) => Task<y, a>*/) {
     super(task)
     this.handle = handle
+  }
+}
+
+class Recover/*::<x, a>*/extends Catch/*::<x, x, a>*/ {
+  /*::
+  regain: (error:x) => a;
+  */
+  constructor(task/*:Task<x, a>*/, regain/*:(error:x) => a*/) {
+    super(task)
+    this.regain = regain
+  }
+  handle(error/*:x*/)/*:Task<x, a>*/ {
+    return new Succeed(this.regain(error))
   }
 }
 

--- a/src/task.js
+++ b/src/task.js
@@ -37,7 +37,7 @@ export class Task /*::<x, a>*/ {
   }
 
   static requestAnimationFrame /*::<x>*/ ()/*:Task<x, Time>*/ {
-    return new RequestAnimationFrame()
+    return new AnimationFrame()
   }
 
   static send /*::<x, a>*/ (address/*:Address<a>*/, message/*:a*/)/*:Task<x, void>*/ {
@@ -124,7 +124,7 @@ class Sleep /*::<x, a:void>*/ extends Task /*::<x, void>*/ {
   }
 }
 
-class RequestAnimationFrame /*::<x>*/ extends Task /*::<x, Time>*/ {
+class AnimationFrame /*::<x>*/ extends Task /*::<x, Time>*/ {
   constructor() {
     super()
   }

--- a/src/task.js.flow
+++ b/src/task.js.flow
@@ -24,6 +24,7 @@ declare export class Task <x, a>
   , static sleep <x> (time:Time): Task<x, void>
   , static send <x, a> (address:Address<a>, action:a):Task<x, void>
   , static fork <x, a, message, reason> (task:Task<x, a>, succeed:(a:a) => void, fail:(x:x) => void):Process<x, a, message, reason>
+  , static requestAnimationFrame <x> (): Task<x, Time>
 
   , constructor (execute:(succeed:(a:a) => void, fail:(x:x) => void) => ?Abort<any>):void
   , chain <b> (chain:(a:a) => Task<x,b>): Task<x,b>

--- a/src/task.js.flow
+++ b/src/task.js.flow
@@ -6,9 +6,6 @@ export type ThreadID = number
 export type Time = number
 export type ProcessID = number
 
-export type Abort <reason> =
-  (reason:reason) => void;
-
 export interface Process <error, value, message, reason>
   { id: ProcessID
   , isActive: boolean
@@ -16,7 +13,7 @@ export interface Process <error, value, message, reason>
 }
 
 declare export class Task <x, a>
-  { static create <x, a> (fork:(succeed:(a:a) => void, fail:(x:x) => void) => ?Abort<any>): Task<x, a>
+  { static create <x, a> (fork:(succeed:(a:a) => void, fail:(x:x) => void) => void): Task<x, a>
   , static future <x, a> (request:() => Promise<a>): Task<x, a>
   , static succeed <x, a> (value:a): Task<x, a>
   , static fail <x, a> (error:x): Task<x, a>
@@ -26,11 +23,12 @@ declare export class Task <x, a>
   , static fork <x, a, message, reason> (task:Task<x, a>, succeed:(a:a) => void, fail:(x:x) => void):Process<x, a, message, reason>
   , static requestAnimationFrame <x> (): Task<x, Time>
 
-  , constructor (execute:(succeed:(a:a) => void, fail:(x:x) => void) => ?Abort<any>):void
+  , constructor <handle> (execute:(succeed:(a:a) => void, fail:(x:x) => void) => handle, cancel?:(handle:handle) => void):void
   , chain <b> (chain:(a:a) => Task<x,b>): Task<x,b>
   , map <b> (map:(input:a) => b): Task<x, b>
   , capture <y> (capture:(error:x) => Task<y, a>): Task<y, a>
   , format <y> (format:(error:x) => y): Task<y, a>
   , recover (regain:(error:x) => a): Task<x, a>
-  , fork (succeed:(a:a) => void, fail:(x:x) => void):void
+  , fork (succeed:(a:a) => void, fail:(x:x) => void):any
+  , abort <handle> (handle:handle):void
 }

--- a/src/task.js.flow
+++ b/src/task.js.flow
@@ -30,5 +30,6 @@ declare export class Task <x, a>
   , map <b> (map:(input:a) => b): Task<x, b>
   , capture <y> (capture:(error:x) => Task<y, a>): Task<y, a>
   , format <y> (format:(error:x) => y): Task<y, a>
+  , recover (regain:(error:x) => a): Task<x, a>
   , fork (succeed:(a:a) => void, fail:(x:x) => void):void
 }


### PR DESCRIPTION
## Overview of the changes

1. Fix regression introduced by 4e13b24 & ba21bbb that cause misbehaviors on synchronous tasks.
2. Factor out `requestAnimationFrame` scheduler from `Effects` library and expose it via tasks instead. Having it part of `Effects` did not really made much sense.
3. Renamed `Effects.task(task)` to `Effects.perform(task)` as former was pretty confusing.
4. Changed API for creating cancellable tasks so they won't perform extra allocations on execution. Most relevant for `requestAnimationFrame` task that are used a lot during animations.
5. Change class hierarchies to avoid passing own methods to super calls.
6. Add `Task.prototype.recover` API so that task failures can more efficiently & intuitively be translated to error actions.